### PR TITLE
feat: Add native PostgreSQL option and LaunchAgent for auto-start

### DIFF
--- a/postgres/README.md
+++ b/postgres/README.md
@@ -2,7 +2,9 @@
 
 Full-featured session search with weighted full-text search, fuzzy matching, and an API server.
 
-## Quick Start
+## Quick Start (Docker)
+
+**Prerequisite:** [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 
 ```bash
 # Start PostgreSQL
@@ -11,8 +13,41 @@ bun run db:up
 # Install dependencies
 bun install
 
-# Set database URL
+# Set database URL (Docker uses port 5433)
 export DATABASE_URL="postgres://claude:sessions@localhost:5433/claude_sessions"
+
+# Sync your sessions
+bun run sync
+
+# Start API server
+bun run serve
+```
+
+## Quick Start (Native)
+
+Alternative if you prefer not to use Docker.
+
+```bash
+# Install PostgreSQL via Homebrew (if not already installed)
+brew install postgresql@14
+
+# Start PostgreSQL
+brew services start postgresql@14
+
+# Create user and database
+psql postgres -c "CREATE USER claude WITH PASSWORD 'sessions';"
+psql postgres -c "CREATE DATABASE claude_sessions OWNER claude;"
+psql postgres -c "GRANT ALL PRIVILEGES ON DATABASE claude_sessions TO claude;"
+
+# Enable required extension and load schema
+psql -d claude_sessions -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
+psql -U claude -d claude_sessions -f schema.sql
+
+# Install dependencies
+bun install
+
+# Set database URL (native uses default port 5432)
+export DATABASE_URL="postgres://claude:sessions@localhost:5432/claude_sessions"
 
 # Sync your sessions
 bun run sync
@@ -140,7 +175,7 @@ Add to crontab for automatic updates:
 */15 * * * * cd /path/to/postgres && DATABASE_URL="..." bun run sync >> /var/log/session-sync.log 2>&1
 ```
 
-## Database Management
+## Database Management (Docker)
 
 ```bash
 # Start database
@@ -156,6 +191,22 @@ bun run db:logs
 bun run db:down
 docker volume rm postgres_postgres_data
 bun run db:up
+```
+
+## Database Management (Native PostgreSQL)
+
+```bash
+# Start PostgreSQL
+brew services start postgresql@14
+
+# Stop PostgreSQL
+brew services stop postgresql@14
+
+# Reset database (delete all data)
+dropdb claude_sessions
+psql postgres -c "CREATE DATABASE claude_sessions OWNER claude;"
+psql -d claude_sessions -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
+psql -U claude -d claude_sessions -f schema.sql
 ```
 
 ## Environment Variables

--- a/postgres/com.kuato.api.plist
+++ b/postgres/com.kuato.api.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+    Kuato API Server LaunchAgent Template
+
+    BEFORE INSTALLING: Update all paths marked with TODO below.
+    See docs/launch-agent.md for detailed instructions.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.kuato.api</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <!-- TODO: Run 'which bun' and paste the result here -->
+        <string>/opt/homebrew/bin/bun</string>
+        <string>run</string>
+        <string>serve</string>
+    </array>
+
+    <!-- TODO: Update to your kuato/postgres directory -->
+    <key>WorkingDirectory</key>
+    <string>/path/to/kuato/postgres</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>DATABASE_URL</key>
+        <!-- Use port 5432 for native PostgreSQL, 5433 for Docker -->
+        <string>postgres://claude:sessions@localhost:5432/claude_sessions</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/kuato-api.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/tmp/kuato-api.error.log</string>
+</dict>
+</plist>


### PR DESCRIPTION
  - Clarify Docker Desktop as explicit prerequisite where needed
  - Add native PostgreSQL setup instructions as Docker alternative (uses port 5432 vs Docker's 5433)
  - Add LaunchAgent template (com.kuato.api.plist) to auto-start API on macOS login
  - Document the two-server architecture (PostgreSQL + Kuato API)
  - Resolves #2

  ---
  The changes span 3 files:  
* `README.md`  (Native PostgreSQL section, LaunchAgent docs)
* `postgres/README.md`  (Native quick start + database management)
* `postgres/com.kuato.api.plist`  (New - LaunchAgent template)
